### PR TITLE
clarify that the Blender importer is deprecated

### DIFF
--- a/source/about/introduction.rst
+++ b/source/about/introduction.rst
@@ -18,7 +18,6 @@ The Assimp-Lib currently supports the following file formats:
 
 * **3D Manufacturing Format** (.3mf)
 * **Collada** (.dae, .xml)
-* **Blender** (.blend)
 * **Biovision BVH** (.bvh) 
 * **3D Studio Max 3DS** (.3ds)
 * **3D Studio Max ASE** (.ase)
@@ -67,6 +66,10 @@ The Assimp-Lib currently supports the following file formats:
 * **Stanford Ply** ( .ply )
 * **TrueSpace** (.cob, .scn)
 * **XGL-3D-Format** (.xgl)
+
+**Important:  Blender (.blend) support is deprecated.**
+**To import a model from Blender, export the model from Blender to glTF.**
+**Sorry for the inconvenience!**
 
 See the:ref:`ai_importer_notes` for information, on what a specific importer can do and what not.
 Note that although this paper claims to be the official documentation,

--- a/source/usage/use_the_lib.rst
+++ b/source/usage/use_the_lib.rst
@@ -1246,6 +1246,8 @@ Blender
 
 This section contains implementation notes for the Blender3D importer.
 
+**Important:  the Blender importer is deprecated.**
+
 .. _ai_bl_overview:
 
 Overview


### PR DESCRIPTION
This clarification is based on recent discussion at https://github.com/assimp/assimp/issues/5299