### PR TITLE
readded API documentation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -19,7 +19,11 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    'breathe',
 ]
+
+breathe_projects = { "AssetImporterLib": "API/" }
+breathe_default_project = "AssetImporterLib"
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),

--- a/source/index.rst
+++ b/source/index.rst
@@ -32,6 +32,13 @@ The Asset-Importer-Lib Documentation
     :name: sec-developer
 
     developer/developer
+
+.. toctree::
+    :maxdepth: 1
+    :caption: API-Reference
+    :name: sec-api
+
+    API/API-Documentation
     
 .. Indices and tables
 .. ==================


### PR DESCRIPTION
The API documentation was removed in commits 33202fb21ef83921be514820d64fc2d389f2a360 (removed breathe) and 2d0b4e0a8bb745101a77fe17e981bd3ca1a6a74f (removed menu entry).

There is currently no online API documentation available, meaning users would have to generate their own doxygen documentation for it. 
I don't see a reason for it not to be a part of this documentation.